### PR TITLE
feat: add persistence manager

### DIFF
--- a/Assets/Scripts/Data.meta
+++ b/Assets/Scripts/Data.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0c1f9d0b5a7e4b7aa1a113c044e6d334
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Data/PersistenceManager.cs
+++ b/Assets/Scripts/Data/PersistenceManager.cs
@@ -1,0 +1,64 @@
+using System.IO;
+using UnityEngine;
+
+[System.Serializable]
+public class GameData
+{
+    public int lastQuestID;
+}
+
+public class PersistenceManager : MonoBehaviour
+{
+    public static PersistenceManager Instance { get; private set; }
+    public GameData data = new GameData();
+
+    private string filePath;
+
+    [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.BeforeSceneLoad)]
+    static void Initialize()
+    {
+        if (Instance == null)
+        {
+            var go = new GameObject("PersistenceManager");
+            Instance = go.AddComponent<PersistenceManager>();
+            DontDestroyOnLoad(go);
+        }
+    }
+
+    void Awake()
+    {
+        filePath = Path.Combine(Application.persistentDataPath, "save.json");
+        LoadGame();
+    }
+
+    public void SaveGame()
+    {
+        var json = JsonUtility.ToJson(data, true);
+        File.WriteAllText(filePath, json);
+    }
+
+    public void LoadGame()
+    {
+        if (File.Exists(filePath))
+        {
+            var json = File.ReadAllText(filePath);
+            data = JsonUtility.FromJson<GameData>(json);
+        }
+    }
+
+    public void OnQuestCompleted(int questId)
+    {
+        data.lastQuestID = questId;
+        SaveGame();
+    }
+
+    public void OnLogout()
+    {
+        SaveGame();
+    }
+
+    void OnApplicationQuit()
+    {
+        OnLogout();
+    }
+}

--- a/Assets/Scripts/Data/PersistenceManager.cs.meta
+++ b/Assets/Scripts/Data/PersistenceManager.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 1f0c9f9a7c3245b7a0de5c9dc6c2e243


### PR DESCRIPTION
## Summary
- add PersistenceManager to handle JSON save/load data in persistent path
- save automatically on quest completion and logout

## Testing
- `pre-commit run --files Assets/Scripts/Data/PersistenceManager.cs Assets/Scripts/Data.meta Assets/Scripts/Data/PersistenceManager.cs.meta` *(fails: command not found)*
- `pip install pre-commit` *(fails: Could not find a version that satisfies the requirement pre-commit)*
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a3238f514483299e5db8887c45af13