### PR TITLE
Add basic inventory, quest and chat systems

### DIFF
--- a/Assets/Resources.meta
+++ b/Assets/Resources.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6816f0a0e66b47eab29995d9db6466b4
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Resources/Items.meta
+++ b/Assets/Resources/Items.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8e4e0ed84fa643eabffeeb4ad0a3f9a5
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Resources/Items/HealthPotion.asset
+++ b/Assets/Resources/Items/HealthPotion.asset
@@ -1,0 +1,17 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 35b7dce02eb040c9ab0f0ef0b2b008ef, type: 3}
+  m_Name: HealthPotion
+  m_EditorClassIdentifier: 
+  id: 1
+  displayName: Health Potion
+  description: Restores 50 HP.

--- a/Assets/Resources/Items/HealthPotion.asset.meta
+++ b/Assets/Resources/Items/HealthPotion.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 7a247e0cb2fb432fabcd1234d56789ef
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Gameplay.meta
+++ b/Assets/Scripts/Gameplay.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 49bb48b399874caab1f2d88c5d9e21aa
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Gameplay/ChatUI.cs
+++ b/Assets/Scripts/Gameplay/ChatUI.cs
@@ -1,0 +1,29 @@
+using System.Collections;
+using UnityEngine;
+using UnityEngine.UI;
+
+public class ChatUI : MonoBehaviour
+{
+    public Text chatText;
+
+    void Start()
+    {
+        if (chatText != null)
+            chatText.text = string.Empty;
+        StartCoroutine(NPCChatter());
+    }
+
+    public void AddMessage(string sender, string message)
+    {
+        if (chatText == null) return;
+        chatText.text += $"\n[{sender}] {message}";
+    }
+
+    IEnumerator NPCChatter()
+    {
+        yield return new WaitForSeconds(2f);
+        AddMessage("NPC", "Welcome to the world!");
+        yield return new WaitForSeconds(5f);
+        AddMessage("NPC", "Let me know if you need anything.");
+    }
+}

--- a/Assets/Scripts/Gameplay/ChatUI.cs.meta
+++ b/Assets/Scripts/Gameplay/ChatUI.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d4d9e1ff2b15458ea7c3d1a5e1b1cf45
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Gameplay/InventorySystem.cs
+++ b/Assets/Scripts/Gameplay/InventorySystem.cs
@@ -1,0 +1,53 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+public class InventorySystem : MonoBehaviour
+{
+    private readonly Dictionary<int, int> items = new Dictionary<int, int>();
+    private readonly Dictionary<int, ItemDefinition> definitions = new Dictionary<int, ItemDefinition>();
+
+    void Awake()
+    {
+        LoadDefinitions();
+    }
+
+    void LoadDefinitions()
+    {
+        ItemDefinition[] defs = Resources.LoadAll<ItemDefinition>("Items");
+        foreach (var def in defs)
+            definitions[def.id] = def;
+    }
+
+    public void AddItem(int id, int amount = 1)
+    {
+        if (!definitions.ContainsKey(id))
+        {
+            Debug.LogWarning($"Item id {id} not found");
+            return;
+        }
+        if (!items.ContainsKey(id))
+            items[id] = 0;
+        items[id] += amount;
+    }
+
+    public bool RemoveItem(int id, int amount = 1)
+    {
+        if (!items.ContainsKey(id) || items[id] < amount)
+            return false;
+        items[id] -= amount;
+        if (items[id] <= 0)
+            items.Remove(id);
+        return true;
+    }
+
+    public int GetItemCount(int id)
+    {
+        return items.TryGetValue(id, out var count) ? count : 0;
+    }
+
+    public ItemDefinition GetItemDefinition(int id)
+    {
+        definitions.TryGetValue(id, out var def);
+        return def;
+    }
+}

--- a/Assets/Scripts/Gameplay/InventorySystem.cs.meta
+++ b/Assets/Scripts/Gameplay/InventorySystem.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 04be889432d44c53ab34fdc3bde5f5b8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Gameplay/ItemDefinition.cs
+++ b/Assets/Scripts/Gameplay/ItemDefinition.cs
@@ -1,0 +1,9 @@
+using UnityEngine;
+
+[CreateAssetMenu(fileName = "Item", menuName = "Game/Item")]
+public class ItemDefinition : ScriptableObject
+{
+    public int id;
+    public string displayName;
+    public string description;
+}

--- a/Assets/Scripts/Gameplay/ItemDefinition.cs.meta
+++ b/Assets/Scripts/Gameplay/ItemDefinition.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 35b7dce02eb040c9ab0f0ef0b2b008ef
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Gameplay/QuestManager.cs
+++ b/Assets/Scripts/Gameplay/QuestManager.cs
@@ -1,0 +1,42 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+public enum QuestState
+{
+    Inactive,
+    Active,
+    Completed
+}
+
+[System.Serializable]
+public class QuestData
+{
+    public string id;
+    public string title;
+    public string description;
+    public QuestState state = QuestState.Inactive;
+}
+
+public class QuestManager : MonoBehaviour
+{
+    public List<QuestData> quests = new List<QuestData>();
+
+    public void StartQuest(string id)
+    {
+        QuestData quest = quests.Find(q => q.id == id);
+        if (quest != null && quest.state == QuestState.Inactive)
+            quest.state = QuestState.Active;
+    }
+
+    public void CompleteQuest(string id)
+    {
+        QuestData quest = quests.Find(q => q.id == id);
+        if (quest != null && quest.state == QuestState.Active)
+            quest.state = QuestState.Completed;
+    }
+
+    public QuestData GetQuest(string id)
+    {
+        return quests.Find(q => q.id == id);
+    }
+}

--- a/Assets/Scripts/Gameplay/QuestManager.cs.meta
+++ b/Assets/Scripts/Gameplay/QuestManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2e64a5f8ee6e4aaabf87b5a2b4ea8b88
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary
- Implement basic inventory system loading item definitions from Resources
- Add quest manager with simple state handling
- Create text chat UI with example NPC chatter

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed / 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a3238fb4e48329af6b5a501247df71