### PR TITLE
Add basic UI prefabs and input manager

### DIFF
--- a/Assets/Prefabs/HealthBar.prefab
+++ b/Assets/Prefabs/HealthBar.prefab
@@ -1,0 +1,87 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &100000
+GameObject:
+  m_ObjectHideFlags: 0
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 22400000}
+  - component: {fileID: 22300000}
+  - component: {fileID: 11400000}
+  m_Layer: 5
+  m_Name: HealthBar
+  m_TagString: Untagged
+  m_IsActive: 1
+--- !u!224 &22400000
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_GameObject: {fileID: 100000}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 22400001}
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 10, y: 10}
+  m_SizeDelta: {x: 200, y: 20}
+  m_Pivot: {x: 0, y: 0}
+--- !u!223 &22300000
+Canvas:
+  m_ObjectHideFlags: 0
+  m_GameObject: {fileID: 100000}
+  m_RenderMode: 0
+  m_SortingOrder: 0
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_GameObject: {fileID: 100000}
+  m_Script: {fileID: 11500000, guid: 0000000000000000d000000000000000, type: 3}
+  m_UiScaleMode: 1
+  m_ReferenceResolution: {x: 1920, y: 1080}
+  m_ScreenMatchMode: 0
+  m_MatchWidthOrHeight: 0
+--- !u!1 &100001
+GameObject:
+  m_ObjectHideFlags: 0
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 22400001}
+  - component: {fileID: 22200001}
+  - component: {fileID: 11400001}
+  m_Layer: 5
+  m_Name: Fill
+  m_TagString: Untagged
+  m_IsActive: 1
+--- !u!224 &22400001
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_GameObject: {fileID: 100001}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 22400000}
+  m_RootOrder: 0
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0, y: 0}
+--- !u!222 &22200001
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_GameObject: {fileID: 100001}
+  m_CullTransparentMesh: 1
+--- !u!114 &11400001
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_GameObject: {fileID: 100001}
+  m_Script: {fileID: 11500000, guid: 0000000000000000f000000000000000, type: 3}
+  m_Color: {r: 1, g: 0, b: 0, a: 1}
+  m_RaycastTarget: 0
+  m_Type: 3
+  m_FillMethod: 0
+  m_FillAmount: 1

--- a/Assets/Prefabs/HealthBar.prefab.meta
+++ b/Assets/Prefabs/HealthBar.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: e1a3a274d8c6485fa334c2b2856c1a1a
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/Inventory.prefab
+++ b/Assets/Prefabs/Inventory.prefab
@@ -1,0 +1,77 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &100000
+GameObject:
+  m_ObjectHideFlags: 0
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 22400000}
+  - component: {fileID: 22300000}
+  - component: {fileID: 11400000}
+  m_Layer: 5
+  m_Name: Inventory
+  m_IsActive: 1
+--- !u!224 &22400000
+RectTransform:
+  m_GameObject: {fileID:100000}
+  m_LocalRotation:{x:0,y:0,z:0,w:1}
+  m_LocalPosition:{x:0,y:0,z:0}
+  m_LocalScale:{x:1,y:1,z:1}
+  m_Children:
+  - {fileID:22400001}
+  m_Father:{fileID:0}
+  m_AnchorMin:{x:0.5,y:0.5}
+  m_AnchorMax:{x:0.5,y:0.5}
+  m_AnchoredPosition:{x:0,y:0}
+  m_SizeDelta:{x:400,y:300}
+  m_Pivot:{x:0.5,y:0.5}
+--- !u!223 &22300000
+Canvas:
+  m_GameObject:{fileID:100000}
+  m_RenderMode:0
+--- !u!114 &11400000
+MonoBehaviour:
+  m_GameObject:{fileID:100000}
+  m_Script:{fileID:11500000, guid:0000000000000000d000000000000000, type:3}
+  m_UiScaleMode:1
+  m_ReferenceResolution:{x:1920,y:1080}
+  m_ScreenMatchMode:0
+  m_MatchWidthOrHeight:0
+--- !u!1 &100001
+GameObject:
+  m_ObjectHideFlags:0
+  serializedVersion:6
+  m_Component:
+  - component:{fileID:22400001}
+  - component:{fileID:22200001}
+  - component:{fileID:11400001}
+  m_Layer:5
+  m_Name:Grid
+  m_IsActive:1
+--- !u!224 &22400001
+RectTransform:
+  m_GameObject:{fileID:100001}
+  m_LocalRotation:{x:0,y:0,z:0,w:1}
+  m_LocalPosition:{x:0,y:0,z:0}
+  m_LocalScale:{x:1,y:1,z:1}
+  m_Children:[]
+  m_Father:{fileID:22400000}
+  m_AnchorMin:{x:0,y:0}
+  m_AnchorMax:{x:1,y:1}
+  m_AnchoredPosition:{x:0,y:0}
+  m_SizeDelta:{x:0,y:0}
+  m_Pivot:{x:0.5,y:0.5}
+--- !u!222 &22200001
+CanvasRenderer:
+  m_GameObject:{fileID:100001}
+  m_CullTransparentMesh:1
+--- !u!114 &11400001
+MonoBehaviour:
+  m_GameObject:{fileID:100001}
+  m_Script:{fileID:11500000, guid:0000000000000000f000000000000000, type:3}
+  m_CellSize:{x:60,y:60}
+  m_Spacing:{x:5,y:5}
+  m_StartCorner:0
+  m_StartAxis:0
+  m_Constraint:1
+  m_ConstraintCount:5

--- a/Assets/Prefabs/Inventory.prefab.meta
+++ b/Assets/Prefabs/Inventory.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 6f2b2d9c29dd45948f02ae3b9a8ab0d7
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/Minimap.prefab
+++ b/Assets/Prefabs/Minimap.prefab
@@ -1,0 +1,74 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &100000
+GameObject:
+  m_ObjectHideFlags: 0
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 22400000}
+  - component: {fileID: 22300000}
+  - component: {fileID: 11400000}
+  m_Layer: 5
+  m_Name: Minimap
+  m_IsActive: 1
+--- !u!224 &22400000
+RectTransform:
+  m_GameObject: {fileID: 100000}
+  m_LocalRotation: {x:0,y:0,z:0,w:1}
+  m_LocalPosition: {x:0,y:0,z:0}
+  m_LocalScale: {x:1,y:1,z:1}
+  m_Children:
+  - {fileID: 22400001}
+  m_Father: {fileID:0}
+  m_AnchorMin: {x:1,y:1}
+  m_AnchorMax: {x:1,y:1}
+  m_AnchoredPosition: {x:-10,y:-10}
+  m_SizeDelta: {x:200,y:200}
+  m_Pivot: {x:1,y:1}
+--- !u!223 &22300000
+Canvas:
+  m_GameObject: {fileID:100000}
+  m_RenderMode:0
+--- !u!114 &11400000
+MonoBehaviour:
+  m_GameObject: {fileID:100000}
+  m_Script: {fileID:11500000, guid: 0000000000000000d000000000000000, type:3}
+  m_UiScaleMode:1
+  m_ReferenceResolution:{x:1920,y:1080}
+  m_ScreenMatchMode:0
+  m_MatchWidthOrHeight:0
+--- !u!1 &100001
+GameObject:
+  m_ObjectHideFlags:0
+  serializedVersion:6
+  m_Component:
+  - component:{fileID:22400001}
+  - component:{fileID:22200001}
+  - component:{fileID:11400001}
+  m_Layer:5
+  m_Name:Image
+  m_IsActive:1
+--- !u!224 &22400001
+RectTransform:
+  m_GameObject:{fileID:100001}
+  m_LocalRotation:{x:0,y:0,z:0,w:1}
+  m_LocalPosition:{x:0,y:0,z:0}
+  m_LocalScale:{x:1,y:1,z:1}
+  m_Children:[]
+  m_Father:{fileID:22400000}
+  m_AnchorMin:{x:0,y:0}
+  m_AnchorMax:{x:1,y:1}
+  m_AnchoredPosition:{x:0,y:0}
+  m_SizeDelta:{x:0,y:0}
+  m_Pivot:{x:0.5,y:0.5}
+--- !u!222 &22200001
+CanvasRenderer:
+  m_GameObject:{fileID:100001}
+  m_CullTransparentMesh:1
+--- !u!114 &11400001
+MonoBehaviour:
+  m_GameObject:{fileID:100001}
+  m_Script:{fileID:11500000, guid: 0000000000000000f000000000000000, type:3}
+  m_Color:{r:1,g:1,b:1,a:1}
+  m_RaycastTarget:0
+  m_Texture:{fileID:0}

--- a/Assets/Prefabs/Minimap.prefab.meta
+++ b/Assets/Prefabs/Minimap.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: b642f060c7af44ab9d5f39e6c834d32a
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/QuestLog.prefab
+++ b/Assets/Prefabs/QuestLog.prefab
@@ -1,0 +1,77 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &100000
+GameObject:
+  m_ObjectHideFlags: 0
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 22400000}
+  - component: {fileID: 22300000}
+  - component: {fileID: 11400000}
+  m_Layer: 5
+  m_Name: QuestLog
+  m_IsActive: 1
+--- !u!224 &22400000
+RectTransform:
+  m_GameObject: {fileID: 100000}
+  m_LocalRotation: {x:0,y:0,z:0,w:1}
+  m_LocalPosition: {x:0,y:0,z:0}
+  m_LocalScale: {x:1,y:1,z:1}
+  m_Children:
+  - {fileID: 22400001}
+  m_Father: {fileID:0}
+  m_AnchorMin: {x:0,y:1}
+  m_AnchorMax: {x:0,y:1}
+  m_AnchoredPosition: {x:10,y:-10}
+  m_SizeDelta: {x:300,y:400}
+  m_Pivot: {x:0,y:1}
+--- !u!223 &22300000
+Canvas:
+  m_GameObject: {fileID:100000}
+  m_RenderMode:0
+--- !u!114 &11400000
+MonoBehaviour:
+  m_GameObject: {fileID:100000}
+  m_Script: {fileID:11500000, guid: 0000000000000000d000000000000000, type:3}
+  m_UiScaleMode:1
+  m_ReferenceResolution:{x:1920,y:1080}
+  m_ScreenMatchMode:0
+  m_MatchWidthOrHeight:0
+--- !u!1 &100001
+GameObject:
+  m_ObjectHideFlags:0
+  serializedVersion:6
+  m_Component:
+  - component:{fileID:22400001}
+  - component:{fileID:22200001}
+  - component:{fileID:11400001}
+  m_Layer:5
+  m_Name:Text
+  m_IsActive:1
+--- !u!224 &22400001
+RectTransform:
+  m_GameObject:{fileID:100001}
+  m_LocalRotation:{x:0,y:0,z:0,w:1}
+  m_LocalPosition:{x:0,y:0,z:0}
+  m_LocalScale:{x:1,y:1,z:1}
+  m_Children:[]
+  m_Father:{fileID:22400000}
+  m_AnchorMin:{x:0,y:1}
+  m_AnchorMax:{x:1,y:1}
+  m_AnchoredPosition:{x:0,y:0}
+  m_SizeDelta:{x:0,y:30}
+  m_Pivot:{x:0.5,y:1}
+--- !u!222 &22200001
+CanvasRenderer:
+  m_GameObject:{fileID:100001}
+  m_CullTransparentMesh:1
+--- !u!114 &11400001
+MonoBehaviour:
+  m_GameObject:{fileID:100001}
+  m_Script:{fileID:11500000, guid: 0000000000000000e000000000000000, type:3}
+  m_Text: "Quest Log"
+  m_FontData:
+    m_FontSize: 24
+    m_FontStyle: 0
+  m_Color: {r:1,g:1,b:1,a:1}
+  m_RaycastTarget:0

--- a/Assets/Prefabs/QuestLog.prefab.meta
+++ b/Assets/Prefabs/QuestLog.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 9d7c6e4e9d974621a66b0f3d5c4c928b
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/UIRoot.prefab
+++ b/Assets/Prefabs/UIRoot.prefab
@@ -1,0 +1,42 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &100000
+GameObject:
+  m_ObjectHideFlags: 0
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4000000}
+  - component: {fileID: 11400000}
+  - component: {fileID: 11400001}
+  - component: {fileID: 11400002}
+  m_Layer: 0
+  m_Name: UIRoot
+  m_IsActive: 1
+--- !u!4 &4000000
+Transform:
+  m_ObjectHideFlags: 0
+  m_GameObject: {fileID: 100000}
+  m_LocalRotation: {x:0,y:0,z:0,w:1}
+  m_LocalPosition: {x:0,y:0,z:0}
+  m_LocalScale: {x:1,y:1,z:1}
+  m_Children: []
+  m_Father: {fileID:0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x:0,y:0,z:0}
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags:0
+  m_GameObject:{fileID:100000}
+  m_Script:{fileID:11500000, guid:0000000000000000e000000000000000, type:3}
+--- !u!114 &11400001
+MonoBehaviour:
+  m_ObjectHideFlags:0
+  m_GameObject:{fileID:100000}
+  m_Script:{fileID:11500000, guid:0000000000000000e000000000000000, type:3}
+  m_ActionsAsset:{fileID:0}
+--- !u!114 &11400002
+MonoBehaviour:
+  m_ObjectHideFlags:0
+  m_GameObject:{fileID:100000}
+  m_Script:{fileID:11500000, guid:5b5a0fcedb6745f5b6c5cf1d2e1e85c3, type:3}
+  actions:{fileID:0, guid:3aa2b8c4ed7643bfbf3a6e7d8fce12d7, type:3}

--- a/Assets/Prefabs/UIRoot.prefab.meta
+++ b/Assets/Prefabs/UIRoot.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: a81cd2bb4e2b447fa20eb9e7318b9e97
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/UI.meta
+++ b/Assets/Scripts/UI.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c6e85ee6184e4c3b89b96bb8dcb39590
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/UI/UIInputManager.cs
+++ b/Assets/Scripts/UI/UIInputManager.cs
@@ -1,0 +1,33 @@
+using UnityEngine;
+using UnityEngine.EventSystems;
+using UnityEngine.InputSystem;
+
+/// <summary>
+/// Configures InputSystemUIInputModule to support keyboard, mouse, and gamepad navigation.
+/// Attach to an EventSystem object and assign an InputActionAsset with a UI action map.
+/// </summary>
+[RequireComponent(typeof(EventSystem))]
+[RequireComponent(typeof(InputSystemUIInputModule))]
+public class UIInputManager : MonoBehaviour
+{
+    [Tooltip("Input actions asset containing a 'UI' action map.")]
+    public InputActionAsset actions;
+
+    void Awake()
+    {
+        var module = GetComponent<InputSystemUIInputModule>();
+        if (actions != null)
+        {
+            // Assign standard UI actions for point, click, navigate, submit and cancel
+            module.actionsAsset = actions;
+            module.point = InputActionReference.Create(actions.FindAction("UI/Point"));
+            module.leftClick = InputActionReference.Create(actions.FindAction("UI/Click"));
+            module.middleClick = InputActionReference.Create(actions.FindAction("UI/MiddleClick"));
+            module.rightClick = InputActionReference.Create(actions.FindAction("UI/RightClick"));
+            module.scrollWheel = InputActionReference.Create(actions.FindAction("UI/ScrollWheel"));
+            module.move = InputActionReference.Create(actions.FindAction("UI/Navigate"));
+            module.submit = InputActionReference.Create(actions.FindAction("UI/Submit"));
+            module.cancel = InputActionReference.Create(actions.FindAction("UI/Cancel"));
+        }
+    }
+}

--- a/Assets/Scripts/UI/UIInputManager.cs.meta
+++ b/Assets/Scripts/UI/UIInputManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5b5a0fcedb6745f5b6c5cf1d2e1e85c3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/UIInputActions.inputactions
+++ b/Assets/UIInputActions.inputactions
@@ -1,0 +1,44 @@
+{
+    "name": "UIInputActions",
+    "maps": [
+        {
+            "name": "UI",
+            "id": "1e6bb5e8-4447-4fb5-9f00-64438e2c9327",
+            "actions": [
+                {"name": "Navigate", "type": "Value", "id": "c1d1a8a7-2a3c-4b5a-b5d3-1c7f1de12345", "expectedControlType": "Vector2"},
+                {"name": "Submit", "type": "Button", "id": "4e9bb0c5-2cf3-4f36-8d67-7564df631111"},
+                {"name": "Cancel", "type": "Button", "id": "8a7f5e3d-4b32-44d9-9ddf-0f4b7a219222"},
+                {"name": "Point", "type": "PassThrough", "id": "197fa5cb-6d4b-4200-93f1-55a1b6733333", "expectedControlType": "Vector2"},
+                {"name": "Click", "type": "PassThrough", "id": "9d0ee1fd-6d5a-4bcf-8ec6-0cf0b6bf4444", "expectedControlType": "Button"},
+                {"name": "RightClick", "type": "PassThrough", "id": "0cf1eae1-9d5e-45e7-9ddc-1cbb99a55555", "expectedControlType": "Button"},
+                {"name": "MiddleClick", "type": "PassThrough", "id": "5dcfa447-2582-4d02-86fe-2afccaa66666", "expectedControlType": "Button"},
+                {"name": "ScrollWheel", "type": "PassThrough", "id": "4f168abf-1682-4af5-b11e-8d2f1d777777", "expectedControlType": "Vector2"}
+            ],
+            "bindings": [
+                {"name": "WASD", "id": "bdc274a4-a2b5-4e1d-8dd3-6f6d88888888", "path": "2DVector", "action": "Navigate", "isComposite": true},
+                {"name": "up", "id": "d0d963f8-1f32-4a28-9ee3-8a7d99999999", "path": "<Keyboard>/w", "action": "Navigate", "isPartOfComposite": true},
+                {"name": "down", "id": "06f6371f-f6a1-4c96-8cbe-c0acaaaaaaa1", "path": "<Keyboard>/s", "action": "Navigate", "isPartOfComposite": true},
+                {"name": "left", "id": "861bde54-26bb-4f69-b249-7d5abbbbbbbb", "path": "<Keyboard>/a", "action": "Navigate", "isPartOfComposite": true},
+                {"name": "right", "id": "74ce8f11-841b-4f1e-ae8b-3ed2cccccccc", "path": "<Keyboard>/d", "action": "Navigate", "isPartOfComposite": true},
+                {"id": "2ed16205-8651-4f35-82cf-ea89dddddddd", "path": "<Keyboard>/enter", "action": "Submit"},
+                {"id": "4b2a3412-9d77-4d42-a09e-f8bfeeeeeeee", "path": "<Keyboard>/escape", "action": "Cancel"},
+                {"id": "70341cae-3581-4b34-8d75-8cff00000000", "path": "<Mouse>/position", "action": "Point"},
+                {"id": "cb3d2eea-5653-44e2-857c-39f7f1111111", "path": "<Mouse>/leftButton", "action": "Click"},
+                {"id": "53a30ff9-3bd8-4a78-8d48-76f812222222", "path": "<Mouse>/rightButton", "action": "RightClick"},
+                {"id": "ad6869d0-9639-4b0c-9cb5-990e43333333", "path": "<Mouse>/middleButton", "action": "MiddleClick"},
+                {"id": "d4887e6f-c4da-4c36-896d-7a7f24444444", "path": "<Mouse>/scroll", "action": "ScrollWheel"},
+                {"name": "Gamepad", "id": "42c67f5f-882b-493f-8c97-d09555555555", "path": "2DVector", "action": "Navigate", "isComposite": true},
+                {"name": "up", "id": "141441b3-8b6c-47e5-8338-6d8e66666666", "path": "<Gamepad>/leftStick/up", "action": "Navigate", "isPartOfComposite": true},
+                {"name": "down", "id": "84bb546a-8d7c-47ba-84e4-fd8777777777", "path": "<Gamepad>/leftStick/down", "action": "Navigate", "isPartOfComposite": true},
+                {"name": "left", "id": "5ec1bd56-5f3f-4da9-9122-a04888888888", "path": "<Gamepad>/leftStick/left", "action": "Navigate", "isPartOfComposite": true},
+                {"name": "right", "id": "02b7859d-5043-4744-af4d-421599999999", "path": "<Gamepad>/leftStick/right", "action": "Navigate", "isPartOfComposite": true},
+                {"id": "dd957f9e-0a6b-4a7c-9a76-6606aaaaaaab", "path": "<Gamepad>/buttonSouth", "action": "Submit"},
+                {"id": "a1cd82bc-7fe2-4f91-aa4c-0d65bbbbbbbb", "path": "<Gamepad>/buttonEast", "action": "Cancel"}
+            ]
+        }
+    ],
+    "controlSchemes": [
+        {"name": "Keyboard&Mouse", "bindingGroup": "Keyboard&Mouse", "devices": ["<Keyboard>", "<Mouse>"]},
+        {"name": "Gamepad", "bindingGroup": "Gamepad", "devices": ["<Gamepad>"]}
+    ]
+}

--- a/Assets/UIInputActions.inputactions.meta
+++ b/Assets/UIInputActions.inputactions.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3aa2b8c4ed7643bfbf3a6e7d8fce12d7
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary
- Add health bar, minimap, quest log, and inventory UI prefabs with CanvasScaler for resolution independence
- Introduce UIInputManager and UI action asset to support keyboard, mouse, and controller navigation
- Provide UIRoot prefab configuring EventSystem and Input System module

## Testing
- ⚠️ `dotnet build` (command not found)


------
https://chatgpt.com/codex/tasks/task_e_68a32391dff0832999818f6c5691190d