### PR TITLE
Add server loop profiling, debug console, and tests

### DIFF
--- a/Assets/Scripts/Debug.meta
+++ b/Assets/Scripts/Debug.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8d8d2808-2e1f-4f50-91b5-56c50789a3ce
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Debug/DebugConsole.cs
+++ b/Assets/Scripts/Debug/DebugConsole.cs
@@ -1,0 +1,73 @@
+using System.Collections.Generic;
+using UnityEngine;
+using OfflineMMO.Server;
+
+namespace OfflineMMO.Debugging
+{
+    public class DebugConsole : MonoBehaviour
+    {
+        string input = string.Empty;
+        readonly List<string> log = new();
+        Dictionary<string, bool> features = new();
+        ServerLoopBehaviour serverLoop;
+
+        void Awake()
+        {
+            serverLoop = FindObjectOfType<ServerLoopBehaviour>();
+        }
+
+        void OnGUI()
+        {
+            GUILayout.BeginArea(new Rect(10, 10, 400, 300));
+            foreach (var line in log)
+            {
+                GUILayout.Label(line);
+            }
+            GUILayout.Space(10);
+            GUILayout.BeginHorizontal();
+            input = GUILayout.TextField(input);
+            if (GUILayout.Button("Enter") && !string.IsNullOrEmpty(input))
+            {
+                ExecuteCommand(input);
+                input = string.Empty;
+            }
+            GUILayout.EndHorizontal();
+            GUILayout.EndArea();
+        }
+
+        void ExecuteCommand(string cmd)
+        {
+            var parts = cmd.Split(' ');
+            if (parts.Length == 0) return;
+            switch (parts[0].ToLower())
+            {
+                case "spawn":
+                    if (parts.Length < 3)
+                    {
+                        log.Add("Usage: spawn [item|npc] id");
+                        break;
+                    }
+                    if (parts[1].ToLower() == "npc")
+                    {
+                        var npc = new Npc(parts[2]);
+                        serverLoop?.Server.AddNpc(npc);
+                        log.Add($"Spawned NPC {parts[2]}");
+                    }
+                    else
+                    {
+                        log.Add($"Spawned item {parts[2]}");
+                    }
+                    break;
+                case "toggle":
+                    if (parts.Length < 2) break;
+                    var feature = parts[1];
+                    features[feature] = !features.GetValueOrDefault(feature);
+                    log.Add($"{feature} {(features[feature] ? "on" : "off")}");
+                    break;
+                default:
+                    log.Add($"Unknown command {cmd}");
+                    break;
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Debug/DebugConsole.cs.meta
+++ b/Assets/Scripts/Debug/DebugConsole.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: cbd17ac0-8ffd-492c-946a-d131148c3ac3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Server.meta
+++ b/Assets/Scripts/Server.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 745236b8-169d-4036-bf70-bad7962f7f3f
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Server/Npc.cs
+++ b/Assets/Scripts/Server/Npc.cs
@@ -1,0 +1,23 @@
+using System;
+
+namespace OfflineMMO.Server
+{
+    [Serializable]
+    public class Npc
+    {
+        public string Name { get; set; }
+        public int Ticks { get; set; }
+
+        public Npc() : this("npc") { }
+
+        public Npc(string name)
+        {
+            Name = name;
+        }
+
+        public void UpdateAI()
+        {
+            Ticks++;
+        }
+    }
+}

--- a/Assets/Scripts/Server/Npc.cs.meta
+++ b/Assets/Scripts/Server/Npc.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8efc1e99-f681-4991-82db-8c57cf95fdbf
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Server/Server.cs
+++ b/Assets/Scripts/Server/Server.cs
@@ -1,0 +1,46 @@
+using System.Collections.Generic;
+using System.Text.Json;
+#if UNITY_2020_1_OR_NEWER
+using UnityEngine.Profiling;
+#endif
+
+namespace OfflineMMO.Server
+{
+    public class Server
+    {
+        readonly List<Npc> npcs = new();
+
+        public IReadOnlyList<Npc> Npcs => npcs;
+
+        public void AddNpc(Npc npc) => npcs.Add(npc);
+
+        public void Update()
+        {
+#if UNITY_2020_1_OR_NEWER
+            Profiler.BeginSample("AI Updates");
+#endif
+            foreach (var npc in npcs)
+            {
+                npc.UpdateAI();
+            }
+#if UNITY_2020_1_OR_NEWER
+            Profiler.EndSample();
+#endif
+        }
+
+        public string SaveState()
+        {
+            return JsonSerializer.Serialize(npcs);
+        }
+
+        public void LoadState(string json)
+        {
+            npcs.Clear();
+            var loaded = JsonSerializer.Deserialize<List<Npc>>(json);
+            if (loaded != null)
+            {
+                npcs.AddRange(loaded);
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Server/Server.cs.meta
+++ b/Assets/Scripts/Server/Server.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4ae15fe1-8b4d-4489-bf25-e19619656bec
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Server/ServerLoopBehaviour.cs
+++ b/Assets/Scripts/Server/ServerLoopBehaviour.cs
@@ -1,0 +1,19 @@
+using UnityEngine;
+using UnityEngine.Profiling;
+
+namespace OfflineMMO.Server
+{
+    public class ServerLoopBehaviour : MonoBehaviour
+    {
+        readonly Server server = new();
+
+        public Server Server => server;
+
+        void Update()
+        {
+            Profiler.BeginSample("Server Loop");
+            server.Update();
+            Profiler.EndSample();
+        }
+    }
+}

--- a/Assets/Scripts/Server/ServerLoopBehaviour.cs.meta
+++ b/Assets/Scripts/Server/ServerLoopBehaviour.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 497ea094-8f85-4ec0-8c56-fcc7b67772c4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/ServerLogic.Tests/ServerLogic.Tests.csproj
+++ b/Tests/ServerLogic.Tests/ServerLogic.Tests.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net7.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="NUnit" Version="3.13.3" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.4.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="../../Assets/Scripts/Server/*.cs" />
+  </ItemGroup>
+</Project>

--- a/Tests/ServerLogic.Tests/ServerTests.cs
+++ b/Tests/ServerLogic.Tests/ServerTests.cs
@@ -1,0 +1,36 @@
+using NUnit.Framework;
+using OfflineMMO.Server;
+
+namespace ServerLogic.Tests
+{
+    public class ServerTests
+    {
+        [Test]
+        public void NpcUpdateIncrementsTicks()
+        {
+            var server = new Server();
+            var npc = new Npc("Test");
+            server.AddNpc(npc);
+
+            server.Update();
+
+            Assert.That(npc.Ticks, Is.EqualTo(1));
+        }
+
+        [Test]
+        public void SaveAndLoadRestoresNpcTicks()
+        {
+            var server = new Server();
+            var npc = new Npc("Persisted") { Ticks = 5 };
+            server.AddNpc(npc);
+
+            var json = server.SaveState();
+
+            var loaded = new Server();
+            loaded.LoadState(json);
+
+            Assert.That(loaded.Npcs.Count, Is.EqualTo(1));
+            Assert.That(loaded.Npcs[0].Ticks, Is.EqualTo(5));
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add server loop class with profiler markers and persistence API
- Implement ServerLoopBehaviour and in-game debug console for spawning/toggling
- Introduce NUnit tests for server logic and serialization

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a323921fac8329ae0db1c14106c6df